### PR TITLE
Fix Kotlin plugin version conflict

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,8 +1,8 @@
 // yicksync/android/build.gradle.kts (项目级)
 
 plugins {
-    id("com.android.application") version "8.4.1" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.23" apply false
+    id("com.android.application") apply false
+    id("org.jetbrains.kotlin.android") apply false
     id("dev.flutter.flutter-gradle-plugin") apply false
 }
 


### PR DESCRIPTION
## Summary
- remove explicit plugin versions from the top-level Android Gradle build script so that pluginManagement controls the versions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d650d1390083269efbcf846357d002